### PR TITLE
Numeric Reply 메소드 호출 방식 통일

### DIFF
--- a/include/Message.hpp
+++ b/include/Message.hpp
@@ -29,12 +29,13 @@ public:
     ~Message();
     Message &operator=(Message const &other);
 
-    size_t getParamSize() const;
     command_t getCommand() const;
+    size_t getParamSize() const;
     std::string getParam(size_t index) const;
     std::string getParam() const;
-    std::string getParamsAll(int index, char ignore = 0) const;
-    std::vector<std::string> getSplitedParam(int index, char delimiter) const;
+    std::string joinParams(size_t startIndex, char ignore = 0) const;
+    std::string joinParams() const;
+    std::vector<std::string> splitParam(int index, char delimiter) const;
 
 private:
     command_t command;

--- a/include/NumericReply.hpp
+++ b/include/NumericReply.hpp
@@ -21,23 +21,14 @@
 #define RPL_NOTOPIC 331
 #define RPL_NOTOPIC_MESSAGE "No topic is set"
 
-#define RPL_TOPIC 332
+#define RPL_TOPIC 332 // "<client> <channel> :<topic>"
 #define RPL_TOPIC_MESSAGE(channelTopic) (channelTopic)
 
-#define RPL_NAMREPLY 353
+#define RPL_NAMREPLY 353 // "<client> <symbol> <channel> :[prefix]<nick>{ [prefix]<nick>}"
 #define RPL_NAMREPLY_MESSAGE(userList) (userList)
 
-#define RPL_ENDOFNAMES 366
-#define RPL_ENDOFNAMES_MESSAGE(param) (param)
-
-#define RPL_TOPIC 332
-#define RPL_TOPIC_MESSAGE(channelTopic) (channelTopic)
-
-#define RPL_NAMREPLY 353
-#define RPL_NAMREPLY_MESSAGE(userList) (userList)
-
-#define RPL_ENDOFNAMES 366
-#define RPL_ENDOFNAMES_MESSAGE(param) (param)
+#define RPL_ENDOFNAMES 366 // "<client> <channel> :End of /NAMES list"
+#define RPL_ENDOFNAMES_MESSAGE "End of /NAMES list"
 
 #define ERR_NOSUCHCHANNEL 403
 #define ERR_NOSUCHCHANNEL_MESSAGE "No such channel"
@@ -100,7 +91,7 @@
 class NumericReply {
 public:
     NumericReply(int code);
-    NumericReply(int code, std::string const  &param);
+    NumericReply(int code, std::string const &param);
 
     NumericReply &operator<<(char const *str);
     NumericReply &operator<<(std::string const &str);
@@ -111,21 +102,14 @@ public:
     void operator>>(Channel &channel);
     void operator>>(Channel *channel);
 
-    static std::string get(int code);
-    static std::string get(int code, std::string const &param);
-    static std::string get(int code, Session const &session);
-    static std::string channelReply(int code, std::string const &nickname, std::string const &channelName);
-
 private:
     const std::string _message;
     std::stringstream _ss;
 
-    static std::string message(int code);
-    static std::string message(int code, Session const &session);
+    std::string message(int code);
     std::string message(int code, std::string const &param);
-    static void append(std::stringstream &ss, int code);
-    static void append(std::stringstream &ss, std::string const &str);
-    static void appendMessage(std::stringstream &ss, std::string const &message);
+    void appendCode(int code);
+    void appendMessage();
 };
 
 #endif //FT_IRC_NUMERICREPLY_HPP

--- a/src/ChatService.cpp
+++ b/src/ChatService.cpp
@@ -9,12 +9,12 @@ ChatService::ChatService(std::string const &password) : password(password) {}
 ChatService::~ChatService() {}
 
 void ChatService::unknown(Session &session, Message const &message) {
-    session << NumericReply::get(ERR_UNKNOWNCOMMAND, message.getParam(0));
+    NumericReply(ERR_UNKNOWNCOMMAND) << session << message.getParam() >> session;
 }
 
 void ChatService::_register(Session &session) {
-    session << NumericReply::get(RPL_WELCOME, session);
-    session << NumericReply::get(RPL_YOURHOST, session);
-    session << NumericReply::get(RPL_CREATED, session);
+    NumericReply(RPL_WELCOME, session.getAddress()) << session >> session;
+    NumericReply(RPL_YOURHOST, session.getServername()) << session >> session;
+    NumericReply(RPL_CREATED) << session >> session;
     session.setRegistered();
 }

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -26,14 +26,13 @@ size_t Message::getParamSize() const {
     return this->params.size();
 }
 
-
 Message::command_t Message::getCommand() const {
     return this->command;
 }
 
 std::string Message::getParam(size_t index) const {
     if (index >= this->params.size()) {
-        return "";
+        return std::string();
     }
     return this->params[index];
 }
@@ -42,13 +41,16 @@ std::string Message::getParam() const {
     return this->getParam(0);
 }
 
-std::string Message::getParamsAll(int index, char ignore) const {
+std::string Message::joinParams(size_t startIndex, char ignore) const {
+    if (startIndex >= params.size()) {
+        return std::string();
+    }
+
     std::stringstream ss;
     std::string param;
 
-    while (!(param = getParam(index)).empty()) {
-        ss << param;
-        index++;
+    for (size_t i = startIndex; i < params.size(); i++) {
+        ss << params[i];
     }
 
     if (ignore && ss.peek() == ignore) {
@@ -58,7 +60,11 @@ std::string Message::getParamsAll(int index, char ignore) const {
     return ss.str();
 }
 
-std::vector<std::string> Message::getSplitedParam(int index, char delimiter) const {
+std::string Message::joinParams() const {
+    return joinParams(0, 0);
+}
+
+std::vector<std::string> Message::splitParam(int index, char delimiter) const {
     std::vector<std::string> splited;
     std::stringstream ss(getParam(index));
     std::string str;

--- a/src/commands/join.cpp
+++ b/src/commands/join.cpp
@@ -12,12 +12,12 @@ void ChannelService::join(Session &session, const Message &message) {
         return NumericReply(ERR_NOTREGISTERED) >> session;
     }
 
-    std::vector<std::string> channels = message.getSplitedParam(0, ',');
+    std::vector<std::string> channels = message.splitParam(0, ',');
     if (channels.empty()) {
         return NumericReply(ERR_NEEDMOREPARAMS) << session << "JOIN" >> session;
     }
 
-    std::vector<std::string> keys = message.getSplitedParam(1, ',');
+    std::vector<std::string> keys = message.splitParam(1, ',');
     std::vector<std::string>::iterator keyIt = keys.begin();
     for (std::vector<std::string>::iterator channelIt = channels.begin(); channelIt != channels.end(); ++channelIt) {
         if (!isValidChannel(*channelIt)) {

--- a/src/commands/join.cpp
+++ b/src/commands/join.cpp
@@ -4,8 +4,7 @@
 
 #include "ChannelService.hpp"
 
-#define RPL_JOIN_CHANNEL(nickname, channelName) (nickname + " JOIN " + channelName)
-
+std::string RPL_JOIN(Session const &session, std::string const &channelName);
 bool isValidChannel(const std::string &channel);
 
 void ChannelService::join(Session &session, const Message &message) {
@@ -46,12 +45,12 @@ void Channel::join(Session *session, const std::string &key) {
     //  Channel 이 UserList를 들고 display
 
     // TODO: 나중에 방의 옵션(#, &)을 달아줘야 함
-    *this << RPL_JOIN_CHANNEL(session->getNickname(), name);
+    *this << RPL_JOIN(*session, name);
     if (!topic.empty()) {
         NumericReply(RPL_TOPIC, this->topic) << session << name >> session;
     }
     NumericReply(RPL_NAMREPLY, userList) << session << name >> session;
-    NumericReply(RPL_ENDOFNAMES, "End of /NAMES list") << session << name >> session;
+    NumericReply(RPL_ENDOFNAMES) << session << name >> session;
 }
 
 bool isValidChannel(const std::string &channel) {
@@ -59,4 +58,12 @@ bool isValidChannel(const std::string &channel) {
         return false;
     }
     return (channel[0] == '#' || channel[0] == '&');
+}
+
+std::string RPL_JOIN(Session const &session, std::string const &channelName) {
+    std::stringstream ss;
+    ss << MESSAGE_PREFIX << session.getAddress() << DELIMITER
+       << "JOIN" << DELIMITER
+       << channelName << CRLF;
+    return ss.str();
 }

--- a/src/commands/kick.cpp
+++ b/src/commands/kick.cpp
@@ -14,7 +14,7 @@ void ChannelService::kick(Session *session, const Message &message) {
         return NumericReply(ERR_NOTREGISTERED) >> session;
     }
 
-    std::vector<std::string> users = message.getSplitedParam(1, ',');
+    std::vector<std::string> users = message.splitParam(1, ',');
     if (users.empty()) {
         return NumericReply(ERR_NEEDMOREPARAMS) << session << "KICK" >> session;
     }
@@ -31,7 +31,7 @@ void ChannelService::kick(Session *session, const Message &message) {
         return NumericReply(ERR_CHANOPRIVSNEEDED) << session << channelName >> session;
     }
 
-    std::string const &comment = message.getParamsAll(2);
+    std::string const &comment = message.joinParams(2);
     for (str_iter user = users.begin(); user != users.end(); user++) {
         Session *participant = channel->getParticipant(*user);
         if (!participant) {

--- a/src/commands/kick.cpp
+++ b/src/commands/kick.cpp
@@ -6,8 +6,8 @@
 
 typedef std::vector<std::string>::const_iterator str_iter;
 
-std::string RPL_CHANNELKICK(Session *_operator, std::string const &channel, std::string const &user,
-                            std::string const &comment);
+std::string RPL_KICK(Session *_operator, std::string const &channel, std::string const &user,
+                     std::string const &comment);
 
 void ChannelService::kick(Session *session, const Message &message) {
     if (!session->isRegistered()) {
@@ -19,7 +19,7 @@ void ChannelService::kick(Session *session, const Message &message) {
         return NumericReply(ERR_NEEDMOREPARAMS) << session << "KICK" >> session;
     }
 
-    std::string channelName = message.getParam(0);
+    std::string const &channelName = message.getParam(0);
     Channel *channel = findChannel(channelName);
     if (!channel) {
         return NumericReply(ERR_NOSUCHCHANNEL) << session << channelName >> session;
@@ -31,20 +31,20 @@ void ChannelService::kick(Session *session, const Message &message) {
         return NumericReply(ERR_CHANOPRIVSNEEDED) << session << channelName >> session;
     }
 
-    std::string comment = message.getParamsAll(2);
+    std::string const &comment = message.getParamsAll(2);
     for (str_iter user = users.begin(); user != users.end(); user++) {
         Session *participant = channel->getParticipant(*user);
         if (!participant) {
             NumericReply(ERR_USERNOTINCHANNEL) << session << *user << channelName >> session;
         } else {
-            *channel << RPL_CHANNELKICK(session, channelName, *user, comment);
+            *channel << RPL_KICK(session, channelName, *user, comment);
             channel->remove(participant);
         }
     }
 }
 
-std::string RPL_CHANNELKICK(Session *_operator, std::string const &channel, std::string const &user,
-                            std::string const &comment) {
+std::string RPL_KICK(Session *_operator, std::string const &channel, std::string const &user,
+                     std::string const &comment) {
     std::stringstream ss;
     ss << MESSAGE_PREFIX << _operator->getAddress() << DELIMITER
        << "KICK" << DELIMITER

--- a/src/commands/part.cpp
+++ b/src/commands/part.cpp
@@ -13,8 +13,8 @@ void ChannelService::part(Session &session, const Message &message) {
         return NumericReply(ERR_NOTREGISTERED) >> session;
     }
 
-    std::vector<std::string> channels = message.getSplitedParam(0, ',');
-    std::string const &reason = message.getParamsAll(1);
+    std::vector<std::string> channels = message.splitParam(0, ',');
+    std::string const &reason = message.joinParams(1);
     if (channels.empty()) {
         return NumericReply(ERR_NEEDMOREPARAMS) << session << "PART" >> session;
     }

--- a/src/commands/part.cpp
+++ b/src/commands/part.cpp
@@ -4,19 +4,19 @@
 
 #include "ChannelService.hpp"
 
-#define RPL_CHANNELPART(clientAddress, channelName, reason) (":" + clientAddress + " PART " + channelName + " " + reason + CRLF)
+std::string RPL_PART(Session &session, const std::string &channelName, const std::string &reason);
 
 typedef std::vector<std::string>::const_iterator iterator;
 
 void ChannelService::part(Session &session, const Message &message) {
     if (!session.isRegistered()) {
-        return session << NumericReply::get(ERR_NOTREGISTERED);
+        return NumericReply(ERR_NOTREGISTERED) >> session;
     }
 
     std::vector<std::string> channels = message.getSplitedParam(0, ',');
-    std::string reason = message.getParamsAll(1);
+    std::string const &reason = message.getParamsAll(1);
     if (channels.empty()) {
-        return session << NumericReply::get(ERR_NEEDMOREPARAMS, "PART");
+        return NumericReply(ERR_NEEDMOREPARAMS) << session << "PART" >> session;
     }
 
     for (iterator it = channels.begin(); it != channels.end(); it++) {
@@ -26,19 +26,28 @@ void ChannelService::part(Session &session, const Message &message) {
 
 void ChannelService::part(Session &session, std::string const &channelName, std::string const &reason) {
     if (!findChannel(channelName)) {
-        return session << NumericReply::channelReply(ERR_NOSUCHCHANNEL, session.getNickname(), channelName);
+        return NumericReply(ERR_NOSUCHCHANNEL) << session << channelName >> session;
     }
 
     Channel *channel = session.findJoinedChannel(channelName);
     if (!channel) {
-        return session << NumericReply::channelReply(ERR_NOTONCHANNEL, session.getNickname(), channelName);
+        return NumericReply(ERR_NOTONCHANNEL) << session << channelName >> session;
     }
 
     int remain = channel->remove(&session);
-    std::string reply = RPL_CHANNELPART(session.getAddress(), channelName, reason);
+    std::string const &reply = RPL_PART(session, channelName, reason);
     session << reply;
     if (remain) {
         return channel->broadcast(reply);
     }
     deleteChannel(channelName);
+}
+
+std::string RPL_PART(Session &session, const std::string &channelName, const std::string &reason) {
+    std::stringstream ss;
+    ss << MESSAGE_PREFIX << session.getAddress() << DELIMITER
+       << "PART" << DELIMITER
+       << channelName << DELIMITER
+       << reason << CRLF;
+    return ss.str();
 }

--- a/src/commands/pass.cpp
+++ b/src/commands/pass.cpp
@@ -5,15 +5,15 @@
 #include "ChatService.hpp"
 
 void ChatService::pass(Session &session, const Message &message) {
-    std::string pw = message.getParam();
+    std::string const &pw = message.getParam();
     if (pw.empty()) {
-        return session << NumericReply::get(ERR_NEEDMOREPARAMS, "PASS");
+        return NumericReply(ERR_NEEDMOREPARAMS) << "PASS" >> session;
     }
     if (pw != this->password) {
-        return session << NumericReply::get(ERR_PASSWDMISMATCH);
+        return NumericReply(ERR_PASSWDMISMATCH) >> session;
     }
     if (session.isPassed()) {
-        return session << NumericReply::get(ERR_ALREADYREGISTRED);
+        return NumericReply(ERR_ALREADYREGISTRED) >> session;
     }
     session.setPassed();
 }

--- a/src/commands/ping.cpp
+++ b/src/commands/ping.cpp
@@ -3,7 +3,7 @@
 std::string RPL_PONG(std::string const &token);
 
 void ChatService::ping(Session &session, const Message &message) {
-    std::string const &token = message.getParamsAll(0);
+    std::string const &token = message.joinParams();
     if (token.empty()) {
         return NumericReply(ERR_NEEDMOREPARAMS) << session << "PING" >> session;
     }

--- a/src/commands/ping.cpp
+++ b/src/commands/ping.cpp
@@ -1,12 +1,18 @@
 #include "ChatService.hpp"
 
-#define RPL_PONG(params) ("PONG :" + params + CRLF)
+std::string RPL_PONG(std::string const &token);
 
 void ChatService::ping(Session &session, const Message &message) {
-    std::string token = message.getParam();
+    std::string const &token = message.getParamsAll(0);
     if (token.empty()) {
-        return session << NumericReply::get(ERR_NEEDMOREPARAMS, "PING");
-    } else {
-        session << RPL_PONG(token);
-     }
+        return NumericReply(ERR_NEEDMOREPARAMS) << session << "PING" >> session;
+    }
+    session << RPL_PONG(token);
+}
+
+std::string RPL_PONG(std::string const &token) {
+    std::stringstream ss;
+    ss << "PONG" << DELIMITER
+       << MESSAGE_PREFIX << token << CRLF;
+    return ss.str();
 }

--- a/src/commands/topic.cpp
+++ b/src/commands/topic.cpp
@@ -13,7 +13,7 @@ void ChannelService::topic(Session &session, const Message &message) {
     }
 
     std::string channelName = message.getParam();
-    std::string topicName = message.getParamsAll(1, ':');
+    std::string topicName = message.joinParams(1, ':');
     bool newTopic = message.getParamSize() > 1;
     Channel *channel = findChannel(channelName);
 

--- a/src/commands/user.cpp
+++ b/src/commands/user.cpp
@@ -12,7 +12,7 @@ void ChatService::user(Session &session, Message const &message) {
         return NumericReply(ERR_ALREADYREGISTRED) << session >> session;
     }
 
-    std::string const &realname = message.getParamsAll(3, ':');
+    std::string const &realname = message.joinParams(3, ':');
     if (realname.empty()) {
         return NumericReply(ERR_NEEDMOREPARAMS) << "USER" >> session;
     }

--- a/src/commands/user.cpp
+++ b/src/commands/user.cpp
@@ -6,15 +6,15 @@
 
 void ChatService::user(Session &session, Message const &message) {
     if (!session.isPassed()) {
-        return session << NumericReply::get(ERR_NOTREGISTERED);
+        return NumericReply(ERR_NOTREGISTERED) >> session;
     }
     if (session.isRegistered()) {
-        return session << NumericReply::get(ERR_ALREADYREGISTRED);
+        return NumericReply(ERR_ALREADYREGISTRED) << session >> session;
     }
 
-    std::string realname = message.getParamsAll(3, ':');
+    std::string const &realname = message.getParamsAll(3, ':');
     if (realname.empty()) {
-        return session << NumericReply::get(ERR_NEEDMOREPARAMS, "USER");
+        return NumericReply(ERR_NEEDMOREPARAMS) << "USER" >> session;
     }
 
     session.updateUser(message.getParam(0), message.getParam(1), message.getParam(2), realname);


### PR DESCRIPTION
Resolved #24 

# 변경사항
1. numeric reply 메소드 호출 방식 통일
1. numeric reply가 아닌 메시지를 매크로 방식에서 함수로 변경
2. numeric reply가 아닌 메시지 함수 이름 통일 (`RPL_<command>`)
3. Message 클래스 메소드 이름 변경
   - getParamsAll -> joinParams
   - getSplitedParam -> splitParam